### PR TITLE
[DEV-13]added date to post

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "draft-js": "^0.11.7",
     "es6-shim": "^0.35.8",
     "formik": "^2.4.5",
+    "moment": "^2.29.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet": "^6.1.0",

--- a/src/components/post/post.component.js
+++ b/src/components/post/post.component.js
@@ -11,8 +11,10 @@ import BookmarkIcon from '@mui/icons-material/Bookmark';
 import { getInitials } from '../../utils/get-initials.util';
 import Loader from '../loader/loader.component';
 import { useEffect } from 'react';
+import { formatDate } from '../../utils/format-date.util';
 
 const Post = ({ post }) => {
+    console.log("post", post);
     const { text, name, username, likes, comments, initialLiked = false, initialBookmarked = false } = post;
     const [isLoadingData, setIsLoadingData] = useState(false);
     const [liked, setLiked] = useState(initialLiked);
@@ -43,9 +45,14 @@ const Post = ({ post }) => {
                     <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                         <Box sx={{ display: 'flex', alignItems: 'center' }}>
                             <Avatar sx={{ mr: 1 }}>{getInitials(name)}</Avatar>
-                            <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start' }}>
+                            <Box sx={{ display: 'flex', alignItems: 'center' }} gap={1}>
                                 <Typography variant="subtitle2">{name}</Typography>
                                 <Typography variant="caption">@{username}</Typography>
+                                <Typography variant="caption">&#8226;</Typography>
+                                <Typography variant="caption">{formatDate(post.$createdAt)}</Typography>
+                                {post.$createdAt !== post.$updatedAt && (
+                                    <Typography variant="caption">(edited)</Typography>
+                                )}
                             </Box>
                         </Box>
                         <IconButton>

--- a/src/utils/format-date.util.js
+++ b/src/utils/format-date.util.js
@@ -1,0 +1,25 @@
+import moment from 'moment';
+
+export const formatDate = (date) => {
+    const momentDate = moment(date);
+    const now = moment();
+
+    // Check if the date is within the last few seconds
+    if (now.diff(momentDate, 'seconds') < 5) { // 5 seconds threshold for "just now"
+        return "just now";
+    }
+
+    // For dates within the same year
+    if (momentDate.year() === now.year()) {
+        // If the date is yesterday or older, but within this year
+        if (momentDate.dayOfYear() < now.dayOfYear() - 1) {
+            return momentDate.format('MMM D'); // e.g., Nov 18
+        }
+
+        // For everything else, return relative time
+        return momentDate.fromNow(); // e.g., a minute ago, 10 minutes ago
+    }
+
+    // For dates from previous years
+    return momentDate.format('MMM D, YYYY'); // e.g., Dec 25, 2022
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -7024,6 +7024,11 @@ mkdirp@~0.5.1:
   dependencies:
     minimist "^1.2.6"
 
+moment@^2.29.4:
+  version "2.29.4"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
+  integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"


### PR DESCRIPTION
## Problem
The post was not showing the date/time it was created

## Outcomes
- Created new utils method to format the createdAt property from the post data to display when it was posted next to the username
- Added a condition to show "(edited)" if createdAt and updatedAt were different to get ready for edited posts

## Screenshots/Recordings
![Screenshot 2023-11-19 201725](https://github.com/Rising-Phoenix-Initiative/fitsocial/assets/57048899/4b17b429-b114-4d77-b904-df0d2b05a049)

## Dependencies
Added the dependency "moment" to format the date value from createdAt and to compare it to the current time to get text like just now, 10 seconds ago, 4 hours ago, Nov 18, and Dec 22, 2022

## Testing Done
I create multiple new posts at different times to test out all cases

## Checklist
- [x] The code follows the project's coding standards and style guides.
- [x] Relevant documentation has been updated or added.
- [x] All new and existing tests pass.
- [x] Changes are covered by the test suite where appropriate.
- [x] I have self-reviewed my own code.

## Additional Context
You will need to run "yarn" in your terminal to install the new package

---